### PR TITLE
Drop support for old PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "symfony/framework-bundle": "^2.8 || ^3.0",
         "sonata-project/media-bundle": "^3.0 || ^4.0",
         "sonata-project/classification-bundle": "^3.0 || ^4.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationMediaBundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is the only branch.


## Subject

This is a new bundle so we don't need any support for older PHP versions.
