### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         "php": "^7.1",
         "sonata-project/classification-bundle": "^3.0 || ^4.0",
         "sonata-project/media-bundle": "^3.0 || ^4.0",
-        "symfony/framework-bundle": "^2.8 || ^3.0"
+        "symfony/framework-bundle": "^2.8 || ^3.1"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.1",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/admin-bundle": "^3.4",
-        "symfony/phpunit-bridge": "^2.8 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Admin/Extension/CategoryAdminExtension.php
+++ b/src/Admin/Extension/CategoryAdminExtension.php
@@ -13,6 +13,7 @@ namespace Sonata\ClassificationMediaBundle\Admin\Extension;
 
 use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
 
 final class CategoryAdminExtension extends AbstractAdminExtension
 {
@@ -23,7 +24,7 @@ final class CategoryAdminExtension extends AbstractAdminExtension
     {
         $formMapper
             ->with('General')
-                ->add('media', 'sonata_type_model_list', [
+                ->add('media', ModelListType::class, [
                     'required' => false,
                     'translation_domain' => 'SonataClassificationMediaBundle',
                 ], [

--- a/src/Admin/Extension/CollectionAdminExtension.php
+++ b/src/Admin/Extension/CollectionAdminExtension.php
@@ -13,6 +13,7 @@ namespace Sonata\ClassificationMediaBundle\Admin\Extension;
 
 use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
 
 final class CollectionAdminExtension extends AbstractAdminExtension
 {
@@ -21,7 +22,7 @@ final class CollectionAdminExtension extends AbstractAdminExtension
      */
     public function configureFormFields(FormMapper $formMapper)
     {
-        $formMapper->add('media', 'sonata_type_model_list', [
+        $formMapper->add('media', ModelListType::class, [
             'required' => false,
             'translation_domain' => 'SonataClassificationMediaBundle',
         ], [


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Removed usage of old form type aliases

### Removed
- support for old versions of php and Symfony
```
