### PR TITLE
Dropping support for symfony < 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         "php": "^7.1",
         "sonata-project/classification-bundle": "^3.6 || ^4.0",
         "sonata-project/media-bundle": "^3.10 || ^4.0",
-        "symfony/config": "^2.8 || ^3.2 || ^4.0",
-        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
-        "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
-        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0"
+        "symfony/config": "^3.4 || ^4.2",
+        "symfony/dependency-injection": "^3.4 || ^4.2",
+        "symfony/framework-bundle": "^3.4 || ^4.2",
+        "symfony/http-kernel": "^3.4 || ^4.2"
     },
     "conflict": {
         "sonata-project/admin-bundle": "<3.31 || >=4.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This is the same thing as https://github.com/sonata-project/SonataAdminBundle/pull/5733, dropping support of Symfony < 3.4 and >= 4, < 4.2
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support for Symfony < 3.4
- Support for Symfony >= 4, < 4.2
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->